### PR TITLE
Remove duplicate event entries in control table

### DIFF
--- a/.changeset/silly-wasps-compare.md
+++ b/.changeset/silly-wasps-compare.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Removed duplicate event entries in the control table

--- a/demo/src/my-element/my-element.ts
+++ b/demo/src/my-element/my-element.ts
@@ -18,6 +18,8 @@ import { customElement, property } from "lit/decorators.js";
  * @cssprop [--card-border-radius=8px] - The card border radius
  *
  * @event {MyType} count - This is a custom event
+ * @event {MyType} fakeEvent - This is a custom event
+ * 
  */
 @customElement("my-element")
 export class MyElement extends LitElement {

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -291,6 +291,17 @@ export function getSlots(component?: Component, enabled = true): ArgSet {
 
 export function getEvents(component?: Component): ArgSet {
   const args: ArgTypes = {};
+  const resets: ArgTypes = {};
+
+  component?.events?.forEach((event) => {
+    resets[event.name] = {
+      name: event.name,
+      table: {
+        disable: true,
+      },
+    };
+  });
+
   const events = getComponentEventsWithType(component!);
   events?.forEach((event) => {
     args[`${event.name}-event`] = {
@@ -306,11 +317,12 @@ export function getEvents(component?: Component): ArgSet {
     };
   });
 
-  return { args };
+  return { resets, args };
 }
 
 export function getMethods(component?: Component): ArgSet {
   const args: ArgTypes = {};
+
   const methods = getComponentPublicMethods(component!);
   methods?.forEach((method) => {
     args[`${method.name}-method`] = {


### PR DESCRIPTION
Eliminate duplicate event entries to streamline the control table and improve clarity.