### PR TITLE
added readonly support for properties

### DIFF
--- a/.changeset/rotten-cameras-buy.md
+++ b/.changeset/rotten-cameras-buy.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+added readonly support for properties

--- a/demo/src/my-element/my-element.ts
+++ b/demo/src/my-element/my-element.ts
@@ -53,6 +53,13 @@ export class MyElement extends LitElement {
   @property({ attribute: false, type: Array })
   hobbies: Array<string> = ['baseball', 'soccer', 'tennis'];
 
+  /**
+   * Readonly - returns the time remaining
+   */
+  get timeRemaining(): number {
+    return Math.round(10000 * Math.random());
+  }
+
   /** Increments the `count`. */
   increment() {
     this.count!++;

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -63,7 +63,7 @@ export function getAttributesAndProperties(
       ? (member as any)[`${options.typeRef}`]?.text || member?.type?.text
       : member?.type?.text;
     const propType = cleanUpType(type);
-    const defaultValue = removeQuotes(member.default || "");
+    const defaultValue = member.readonly ? undefined : removeQuotes(member.default || "");
     const control = getControl(propType, attribute !== undefined);
 
     args[name] = {
@@ -73,13 +73,14 @@ export function getAttributesAndProperties(
         propName,
         member.deprecated as string
       ),
-      defaultValue:
-        defaultValue === "''"
-          ? ""
-          : control === "object"
-            ? JSON.parse(formatToValidJson(defaultValue))
-            : defaultValue,
-      control: enabled
+      defaultValue: defaultValue
+          ? defaultValue === "''"
+            ? ""
+            : control === "object"
+              ? JSON.parse(formatToValidJson(defaultValue))
+              : defaultValue
+          : undefined,
+      control: enabled && !member.readonly
         ? {
             type: control,
           }
@@ -142,7 +143,7 @@ export function getReactProperties(
       name: member.name,
       description: member.description,
       defaultValue: getDefaultValue(controlType, member.default),
-      control: enabled
+      control: enabled && !member.readonly
         ? {
             type: controlType,
           }


### PR DESCRIPTION
Hi,

Automatically disable controls in storybook when a property is flagged as readonly in the CEM.

This prevent the generation of a warning in the dev console, when storybook try to do a `set` on a readonly property.

Not sure everything was changed properly, so let me know in case there is any change needed.