### PR TITLE
docs(README): 📖  incorrect import path in README

### DIFF
--- a/.changeset/public-jokes-hear.md
+++ b/.changeset/public-jokes-hear.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fixes an incorrect import path in the documentation

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Next, if you have [global configurations](#global-configurations), set those in 
 
 ```ts
 // preview.js
-import { setStorybookHelpersConfig, type Options } from "@wc-toolbox/storybook-helpers";
+import { setStorybookHelpersConfig, type Options } from "@wc-toolkit/storybook-helpers";
 
 const options: Options = {...}
 


### PR DESCRIPTION
Followed the steps to migrate to the new repo and ran into type errors here, realized that this is a copy/paste issue with the docs. 