### PR TITLE
refactor(types): 🔧 Refactor types to use ArgTypes export from @storybook/web-components

### DIFF
--- a/.changeset/clever-friends-rescue.md
+++ b/.changeset/clever-friends-rescue.md
@@ -2,4 +2,4 @@
 "@wc-toolkit/storybook-helpers": patch
 ---
 
-Adds export for ArgTypes
+Adjusts ArgTypes export to source from Storybook

--- a/.changeset/clever-friends-rescue.md
+++ b/.changeset/clever-friends-rescue.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Adds export for ArgTypes

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -5,7 +5,8 @@ import {
   getMemberDescription,
   removeQuotes,
 } from "@wc-toolkit/cem-utilities";
-import type { ArgTypes, ControlOptions } from "./storybook-types";
+import type { ArgTypes } from "@storybook/web-components";
+import type { ControlOptions } from "./storybook-types";
 import type { Options } from "./types";
 import type { Component } from "@wc-toolkit/cem-utilities";
 
@@ -80,10 +81,8 @@ export function getAttributesAndProperties(
               ? JSON.parse(formatToValidJson(defaultValue))
               : defaultValue
           : undefined,
-      control: enabled && !member.readonly
-        ? {
-            type: control,
-          }
+      control: enabled && !member.readonly && control
+        ? { type: control }
         : false,
       table: {
         category: attribute ? "attributes" : "properties",
@@ -143,11 +142,9 @@ export function getReactProperties(
       name: member.name,
       description: member.description,
       defaultValue: getDefaultValue(controlType, member.default),
-      control: enabled && !member.readonly
-        ? {
-            type: controlType,
-          }
-        : false,
+    control: enabled && !member.readonly && controlType
+      ? { type: controlType }
+      : false,
       table: {
         category: "properties",
         defaultValue: {

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -6,7 +6,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { TemplateResult } from "lit";
 import type { Categories, Options } from "./types";
 import type { Component } from "@wc-toolkit/cem-utilities";
-import type { ArgTypes } from "./storybook-types";
+import type { ArgTypes } from "@storybook/web-components";
 import {
   getAttributesAndProperties,
   getCssParts,

--- a/src/storybook-helpers.ts
+++ b/src/storybook-helpers.ts
@@ -13,7 +13,7 @@ import {
   getMethods,
 } from "./cem-parser.js";
 import { Component, getComponentByTagName } from "@wc-toolkit/cem-utilities";
-import type { ArgTypes } from "./storybook-types";
+import type { ArgTypes } from '@storybook/web-components';
 import type { Categories, Options, StoryHelpers, StoryOptions } from "./types";
 import type { Package } from "custom-elements-manifest";
 

--- a/src/storybook-types.ts
+++ b/src/storybook-types.ts
@@ -1,39 +1,16 @@
-export type ArgSettingsType = {
-  /** Sets a type for the property. */
-  name?: string;
-  /** Sets the property as optional or required. */
-  required?: boolean;
-};
 
-export type Table = {
-  type?: TableType;
-  defaultValue?: TableDefaultValue;
-  /** Removes control from table. */
-  disable?: boolean;
-  /** Assigns control to control group */
-  category?:
-    | "attributes"
-    | "css properties"
-    | "css shadow parts"
-    | "css states"
-    | "events"
-    | "properties"
-    | "methods"
-    | "slots";
-  /** Assigns the argTypes to a specific subcategory */
-  subcategory?: string;
-};
-
-export type TableType = {
-  /** Provide a short version of the type. */
-  summary?: string;
-  /** Provides an extended version of the type. */
-  detail?: string;
-};
-
-export type TableDefaultValue = {
-  /** Provide a short version of the default value. */
-  summary?: string;
-  /** Provides a longer version of the default value. */
-  detail?: string;
-};
+export type ControlOptions =	
+  | "text"	
+  | "radio"	
+  | "select"	
+  | "boolean"	
+  | "number"	
+  | "color"	
+  | "date"	
+  | "object"	
+  | "file"	
+  | "inline-radio"	
+  | "check"	
+  | "inline-check"	
+  | "multi-select"	
+  | null;

--- a/src/storybook-types.ts
+++ b/src/storybook-types.ts
@@ -1,21 +1,3 @@
-// These are types that are from Storybook, but not exported
-
-export type ArgTypes = {
-  [key: string]: ArgSettings;
-};
-
-export type ArgSettings = {
-  /** The name of the property. */
-  name: string;
-  type?: ArgSettingsType;
-  defaultValue?: string | boolean | number | object;
-  /** Sets a Markdown description for the property. */
-  description?: string;
-  table?: Table;
-  control?: Control | ControlOptions | boolean;
-  options?: string[];
-};
-
 export type ArgSettingsType = {
   /** Sets a type for the property. */
   name?: string;

--- a/src/storybook-types.ts
+++ b/src/storybook-types.ts
@@ -37,27 +37,3 @@ export type TableDefaultValue = {
   /** Provides a longer version of the default value. */
   detail?: string;
 };
-
-export type Control = {
-  type: ControlOptions;
-  min?: number;
-  max?: number;
-  step?: number;
-  accept?: string;
-};
-
-export type ControlOptions =
-  | "text"
-  | "radio"
-  | "select"
-  | "boolean"
-  | "number"
-  | "color"
-  | "date"
-  | "object"
-  | "file"
-  | "inline-radio"
-  | "check"
-  | "inline-check"
-  | "multi-select"
-  | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { TemplateResult } from "lit";
-import { ArgTypes } from "./storybook-types";
+import type {
+  ArgTypes
+} from '@storybook/web-components';
 
 export type Categories =
   | "attributes"
@@ -40,5 +42,3 @@ export type StoryHelpers<T> = {
   styleTemplate: (args?: Record<string, unknown>) => TemplateResult | "";
   template: (args?: Partial<T> & { [key: string]: any }, slot?: TemplateResult) => TemplateResult;
 };
-
-export type { ArgTypes }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,3 +40,5 @@ export type StoryHelpers<T> = {
   styleTemplate: (args?: Record<string, unknown>) => TemplateResult | "";
   template: (args?: Partial<T> & { [key: string]: any }, slot?: TemplateResult) => TemplateResult;
 };
+
+export type { ArgTypes }


### PR DESCRIPTION
In the previous version I was able to reach into the dist folder to grab the ArgTypes interface, in the newer version that is not the case. 

In some rare cases I need to avoid the template method, and having this available allows proper type interfaces when moving the data around. 