### PR TITLE
fix: remove unnecessary continue in getSlotsTemplate

### DIFF
--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -299,7 +299,6 @@ function getSlotsTemplate(
       for (const child of container.childNodes) {
         if (child.textContent?.trim() === "" || child.textContent === "\n") {
           slotContent += child.textContent;
-          continue;
         }
 
         if (child instanceof Text) {


### PR DESCRIPTION
Eliminated a redundant continue statement in the getSlotsTemplate function. This was causing things like `<img src="https://jives.dev/icon.png" alt="icon" />` and `<my-element></my-element>` from working as the text content is considered empty. As `continue `was being used it was acting as a return and not triggering the following `else if` statements in the loop.