### PR TITLE
Prevent overwriting existing event handlers from args

### DIFF
--- a/.changeset/silent-donuts-kick.md
+++ b/.changeset/silent-donuts-kick.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Do not overwrite event handlers from args with logEvent-handler

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -185,7 +185,9 @@ function getTemplateOperators(
     if(!event.name) {
       return;
     }
-    additionalAttrs[`@${event.name}`] = (e: Event) => logEvent(event.name, e);
+    if (!additionalAttrs[`@${event.name}`]) {
+      additionalAttrs[`@${event.name}`] = (e: Event) => logEvent(event.name, e);
+    }
   });
 
   return { attrOperators, propOperators, additionalAttrs };


### PR DESCRIPTION
Before 10.2 you could send in an event handler using the `{ handleEvent: () => void }` syntax, but not as a function, this broke when adding the automatic `logEvent` handlers. See #63 for context.

This PR restores pre-10.2 behaviour.