### PR TITLE
Fix URL args being silently dropped when setCustomElementsManifest is active

### DIFF
--- a/.changeset/new-socks-jump.md
+++ b/.changeset/new-socks-jump.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix URL args being silently dropped when setCustomElementsManifest is active

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -94,6 +94,7 @@ export function getAttributesAndProperties(
           summary: type,
         },
       },
+      type: getSBType(control),
     };
 
     const values = control === "select" && propType?.split("|");
@@ -156,6 +157,7 @@ export function getReactProperties(
           summary: type,
         },
       },
+      type: getSBType(controlType),
     };
 
     const values = controlType === "select" && propType?.split("|");
@@ -369,6 +371,25 @@ function getDefaultValue(controlType: ControlOptions, defaultValue?: string) {
     : initialValue === "''"
       ? ""
       : initialValue;
+}
+
+function getSBType(controlType: ControlOptions): ArgTypes[string]["type"] {
+  switch (controlType) {
+    case "boolean":
+      return "boolean";
+    case "number":
+      return "number";
+    case "color":
+    case "text":
+    case "date":
+      return "string";
+    case "select":
+      return { name: "enum", value: [] };
+    case "object":
+      return { name: "object", value: {} };
+    default:
+      return undefined;
+  }
 }
 
 function getControl(type: string, isAttribute = false): ControlOptions {

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -96,7 +96,7 @@ export function getAttributesAndProperties(
       },
     };
 
-    const values = propType?.split("|");
+    const values = control === "select" && propType?.split("|");
     if (values && values?.length > 1) {
       args[name].options = values.map((x) => removeQuotes(x)!);
     }
@@ -158,7 +158,7 @@ export function getReactProperties(
       },
     };
 
-    const values = propType?.split("|");
+    const values = controlType === "select" && propType?.split("|");
     if (values && values?.length > 1) {
       args[propName].options = values.map((x) => removeQuotes(x)!);
     }


### PR DESCRIPTION
# First Commit 

## Reproduction scenario

**Component with an object property:**

```ts
// my-element.ts
@property({ attribute: false, type: Object })
config: Record<string, string | number> = {};
```

**Before the fix**, `getReactProperties()` would produce:

```ts
args['config'] = {
  control: { type: 'object' },  // correct
  options: ['Record<string, string', '>'], //  spurious, object control ignores this
};
```

---

## Root cause

`getReactProperties()` split `propType` on `|` unconditionally, without checking
whether the control was actually `"select"`. Any type containing `|` — including
object/array types like `Record<string, string | number>` — would get a
meaningless `options` array attached. The fix adds the same `controlType === "select"`
guard that `getAttributesAndProperties()` already had.

# Second Commit

## Reproduction scenario

**Component with a union string property:**

```ts
// my-element.ts
@property()
union?: "value1" | "value2" | "value3" | "value4" = "value1";
```

**Both helpers and manifest registered:**

```ts
// .storybook/preview.ts
import { setCustomElementsManifest } from "@storybook/web-components";
import cem from "../custom-elements.json";

setCustomElementsManifest(cem); // ← this is the trigger
```

**Steps to reproduce:**

1. Open the story for `my-element`
2. In the Controls panel, change `union` to `"value3"` -  it works
3. Copy the resulting URL: `?args=union:value3`
4. Paste the URL in a new tab or share it
5. The story opens with `union` still at `"value1"` - the URL arg is silently ignored 

The Controls panel _appears_ to show `"value1"` selected, and the actual
rendered component receives the default `"value1"`.

---

## Root cause

`setCustomElementsManifest` registers an `argTypesEnhancer` that reads the CEM
and injects `type: { name: '"value1" | "value2" | "value3" | "value4"' }` for
the `union` prop. This raw string is not a known `SBType` name.

`storybook-helpers` did not set the `type` field at all, so this raw value was
never overridden during the merge. When Storybook deserialises URL args, it
hits `default: return INCOMPATIBLE` in its internal `mapArgsToTypes()` switch
and **silently drops** the arg.