### PR TITLE
chore: add changeset for PR #67 fix arg observer typo

### DIFF
--- a/.changeset/fix-arg-observer-typo.md
+++ b/.changeset/fix-arg-observer-typo.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix typo in `argsObserver` variable name in `syncControls` function.


### PR DESCRIPTION
## Summary
- Adds a missing patch changeset for PR #67 which fixed a typo in the `argsObserver` variable name in the `syncControls` function.

## Test plan
- [ ] Verify changeset is picked up by changesets bot