### PR TITLE
Fix: only propagate known args to url

### DIFF
--- a/.changeset/eighty-facts-leave.md
+++ b/.changeset/eighty-facts-leave.md
@@ -2,4 +2,4 @@
 "@wc-toolkit/storybook-helpers": minor
 ---
 
-Limit propagation of URL param "args" to known arguments only
+Add support for disabling the propagation of attribute changes to Storybook URL params

--- a/.changeset/eighty-facts-leave.md
+++ b/.changeset/eighty-facts-leave.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": minor
+---
+
+Limit propagation of URL param "args" to known arguments only

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -366,6 +366,10 @@ function syncControls(component: Component) {
  * @param component component object from the Custom Elements Manifest
  */
 function setArgObserver(component: Component) {
+  if(options.disableArgObserver) {
+    return;
+  }
+
   let isUpdating = false;
   const updateArgs = useArgs()[1];
   const { attrArgs: attributes } = getAttributesAndProperties(component);
@@ -391,7 +395,7 @@ function setArgObserver(component: Component) {
             mutation.target as HTMLElement
           )?.hasAttribute(mutation.attributeName || ""),
         });
-      } else if (attribute) {
+      } else {
         updateArgs({
           [`${mutation.attributeName}`]: (
             mutation.target as HTMLElement

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -103,7 +103,7 @@ export function getStyleTemplate(
 
 export function logEvent(name: string, event: Event) {
   const eventData: Record<string, unknown> = {};
-  
+
   for (const key in event) {
     try {
       const value = event[key as keyof Event];
@@ -112,9 +112,9 @@ export function logEvent(name: string, event: Event) {
       // Skip properties that throw errors when accessed
     }
   }
-  
+
   action(name)(eventData);
-};
+}
 
 function excludeCategory(
   category: Categories,
@@ -182,7 +182,7 @@ function getTemplateOperators(
     });
 
   component.events?.forEach((event) => {
-    if(!event.name) {
+    if (!event.name) {
       return;
     }
     if (!additionalAttrs[`@${event.name}`]) {
@@ -391,7 +391,7 @@ function setArgObserver(component: Component) {
             mutation.target as HTMLElement
           )?.hasAttribute(mutation.attributeName || ""),
         });
-      } else {
+      } else if (attribute) {
         updateArgs({
           [`${mutation.attributeName}`]: (
             mutation.target as HTMLElement

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export type StorybookHelpersOptions = {
   renderDefaultValues?: boolean;
   /** Category order */
   categoryOrder?: Array<Categories>;
+  /** Disables the MutationObserver that syncs component attributes and properties with Storybook controls */
+  disableArgObserver?: boolean;
 };
 
 /** @deprecated Use StorybookHelpersOptions instead */


### PR DESCRIPTION
This PR fixes https://github.com/wc-toolkit/storybook-helpers/issues/76 by only calling `updateArgs` for attributes which are known to Storybook.

Note: changes on lines 106, 115, 117, 185 are formatting only