### PR TITLE
Fix: dynamically import `node:path` in node-specific codepath (fixes #88)

### DIFF
--- a/.changeset/lemon-towns-brush.md
+++ b/.changeset/lemon-towns-brush.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fixes an issue where the `path` module could inadvertently be eagerly loaded in a browser environment (and fail) by changing the call to a dynamic import.

--- a/src/reloader.ts
+++ b/src/reloader.ts
@@ -1,5 +1,3 @@
-import path from "path";
-
 /*
  * storybookHelpersReloader
  * ------------------------
@@ -16,7 +14,8 @@ export interface CEMWatchOptions {
   enabled?: boolean;
 }
 
-function resolveManifestPath(configDir?: string, override?: string): string {
+async function resolveManifestPath(configDir?: string, override?: string): Promise<string> {
+  const path = await import("node:path");
   const base = configDir ? path.resolve(configDir) : process.cwd();
   return path.resolve(base, override || "custom-elements.json");
 }
@@ -91,14 +90,14 @@ class WatchCEMWebpackPlugin {
 export function storybookHelpersReloader(opts: CEMWatchOptions = {}) {
   const { path: overridePath, enabled = true } = opts;
 
-  function viteFinal(
+  async function viteFinal(
     existingConfig: Record<string, unknown> | unknown,
     { configDir }: { configDir?: string },
   ) {
     if (!enabled) {
       return existingConfig as unknown;
     }
-    const manifestPath = resolveManifestPath(configDir, overridePath);
+    const manifestPath = await resolveManifestPath(configDir, overridePath);
     const plugin = createViteCEMPlugin(manifestPath);
     const cfg = existingConfig as Record<string, unknown>;
     return {
@@ -107,14 +106,14 @@ export function storybookHelpersReloader(opts: CEMWatchOptions = {}) {
     };
   }
 
-  function webpackFinal(
+  async function webpackFinal(
     existingConfig: Record<string, unknown> | unknown,
     { configDir }: { configDir?: string },
   ) {
     if (!enabled) {
       return existingConfig as unknown;
     }
-    const manifestPath = resolveManifestPath(configDir, overridePath);
+    const manifestPath = await resolveManifestPath(configDir, overridePath);
     const pluginInstance = new WatchCEMWebpackPlugin(manifestPath);
     const cfg = existingConfig as Record<string, unknown>;
     return {


### PR DESCRIPTION
Fix: dynamically import `node:path` in node-specific codepath so top-level import doesn't throw in the browser

Fix for #88 

Promises are supported for both `viteFinal` and `webpackFinal`:
<img width="841" height="398" alt="Screenshot 2026-07-01 at 1 05 16 PM" src="https://github.com/user-attachments/assets/67b7e991-7f96-4e1b-b825-aa9262df9cec" />
<img width="806" height="232" alt="Screenshot 2026-07-01 at 1 04 50 PM" src="https://github.com/user-attachments/assets/724cdb8f-1c2a-460f-ba43-9beb4d3aeba0" />
