### PR TITLE
feat: add `useCssPropTypes` config option for type-based CSS property controls

### DIFF
--- a/.changeset/tricky-dodos-grin.md
+++ b/.changeset/tricky-dodos-grin.md
@@ -5,4 +5,3 @@
 feat: add `useCssPropTypes` config option to infer CSS custom property controls from CEM type instead of property name heuristics
 
 When `setStorybookHelpersConfig({ useCssPropTypes: true })` is set, `getCssPropControl` relies only on the CSS type (`<color>`, `<number>`, `<integer>`) declared in the `@cssproperty` JSDoc tag to determine the Storybook control. The name-based heuristic (`name.includes("color")` / `name.includes("colour")`) is skipped, avoiding false positives for properties like `--colour-distance` or `--profile-icon-colour`.
-

--- a/.changeset/tricky-dodos-grin.md
+++ b/.changeset/tricky-dodos-grin.md
@@ -1,0 +1,8 @@
+---
+"@wc-toolkit/storybook-helpers": minor
+---
+
+feat: add `useCssPropTypes` config option to infer CSS custom property controls from CEM type instead of property name heuristics
+
+When `setStorybookHelpersConfig({ useCssPropTypes: true })` is set, `getCssPropControl` relies only on the CSS type (`<color>`, `<number>`, `<integer>`) declared in the `@cssproperty` JSDoc tag to determine the Storybook control. The name-based heuristic (`name.includes("color")` / `name.includes("colour")`) is skipped, avoiding false positives for properties like `--colour-distance` or `--profile-icon-colour`.
+

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -62,6 +62,7 @@ export function getAttributesAndProperties(
     }
 
     const name = attribute?.name || member.name;
+    const propName = attribute?.name !== member.name ? member.name : undefined;
     const type = helpersOptions.typeRef
       ? (member as any)[`${helpersOptions.typeRef}`]?.text || member?.type?.text
       : member?.type?.text;
@@ -215,7 +216,8 @@ export function getCssProperties(
 function getCssPropControl(
   property: CssCustomProperty,
 ): StorybookControl | undefined {
-  const config: StorybookHelpersOptions = (globalThis as any)?.__WC_STORYBOOK_HELPERS_CONFIG__ || {};
+  const config: StorybookHelpersOptions =
+    (globalThis as any)?.__WC_STORYBOOK_HELPERS_CONFIG__ || {};
   const type = (property as any).type?.text?.toLowerCase();
   const name = property.name?.toLowerCase();
 

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -62,7 +62,7 @@ export function getAttributesAndProperties(
     }
 
     const name = attribute?.name || member.name;
-    const propName = attribute?.name !== member.name ? member.name : undefined;
+    const argRef = attribute?.name !== member.name ? member.name : undefined;
     const type = helpersOptions.typeRef
       ? (member as any)[`${helpersOptions.typeRef}`]?.text || member?.type?.text
       : member?.type?.text;
@@ -78,11 +78,11 @@ export function getAttributesAndProperties(
 
     args[name] = {
       name: name,
-      description: getDescription(
-        (member as any).summary || member.description,
-        propName,
-        member.deprecated as string,
-      ),
+        description: getDescription(
+          (member as any).summary || member.description,
+          argRef,
+          member.deprecated as string,
+        ),
       defaultValue,
       control: enabled && !member.readonly && control ? control : false,
       options,

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -78,11 +78,11 @@ export function getAttributesAndProperties(
 
     args[name] = {
       name: name,
-        description: getDescription(
-          (member as any).summary || member.description,
-          argRef,
-          member.deprecated as string,
-        ),
+      description: getDescription(
+        (member as any).summary || member.description,
+        argRef,
+        member.deprecated as string,
+      ),
       defaultValue,
       control: enabled && !member.readonly && control ? control : false,
       options,

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -212,8 +212,16 @@ export function getCssProperties(
 }
 
 function getCssPropControl(property: CssCustomProperty): StorybookControl | undefined {
+  const config: StorybookHelpersOptions = (globalThis as any)?.__WC_STORYBOOK_HELPERS_CONFIG__ || {};
   const type = (property as any).type?.text?.toLowerCase();
   const name = property.name?.toLowerCase();
+
+  if (config.useCssPropTypes) {
+    if (type === "<color>") return "color";
+    if (type === "<integer>" || type === "<number>") return "number";
+    return "text";
+  }
+
   if (
     name?.includes("color") ||
     name?.includes("colour") ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export type StorybookHelpersOptions = {
   categoryOrder?: Array<Categories>;
   /** Disables the MutationObserver that syncs component attributes and properties with Storybook controls */
   disableArgObserver?: boolean;
+  /** When true, infers CSS custom property controls from their declared CEM type instead of the property name */
+  useCssPropTypes?: boolean;
 };
 
 /** @deprecated Use StorybookHelpersOptions instead */

--- a/test/cem-parser.test.ts
+++ b/test/cem-parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   getAttributesAndProperties,
   getCssParts,
@@ -405,6 +405,73 @@ describe("getCssProperties", () => {
       /* enabled */ false,
     );
     expect(args["--primary-color"].control).toBe(false);
+  });
+
+  describe("useCssPropTypes", () => {
+    const CONFIG_KEY = "__WC_STORYBOOK_HELPERS_CONFIG__";
+
+    beforeEach(() => {
+      (globalThis as any)[CONFIG_KEY] = { useCssPropTypes: true };
+    });
+
+    afterEach(() => {
+      delete (globalThis as any)[CONFIG_KEY];
+    });
+
+    it("uses the CEM type when useCssPropTypes is enabled, ignoring name heuristics", () => {
+      const { args } = getCssProperties(
+        makeComponent({
+          cssProperties: [
+            { name: "--profile-icon-colour", type: { text: "<string>" } } as never,
+          ],
+        }),
+      );
+      expect(args["--profile-icon-colour"].control).toBe("text");
+    });
+
+    it("still maps <color> to a color control", () => {
+      const { args } = getCssProperties(
+        makeComponent({
+          cssProperties: [
+            { name: "--border", type: { text: "<color>" } } as never,
+          ],
+        }),
+      );
+      expect(args["--border"].control).toBe("color");
+    });
+
+    it("still maps <number> to a number control", () => {
+      const { args } = getCssProperties(
+        makeComponent({
+          cssProperties: [
+            { name: "--colour-distance", type: { text: "<number>" } } as never,
+          ],
+        }),
+      );
+      expect(args["--colour-distance"].control).toBe("number");
+    });
+
+    it("falls back to text for unrecognised types like <string>", () => {
+      const { args } = getCssProperties(
+        makeComponent({
+          cssProperties: [
+            { name: "--accent", type: { text: "<string>" } } as never,
+          ],
+        }),
+      );
+      expect(args["--accent"].control).toBe("text");
+    });
+
+    it("ignores the 'color' name heuristic when useCssPropTypes is true", () => {
+      const { args } = getCssProperties(
+        makeComponent({
+          cssProperties: [
+            { name: "--primary-color" },
+          ],
+        }),
+      );
+      expect(args["--primary-color"].control).toBe("text");
+    });
   });
 });
 

--- a/test/cem-parser.test.ts
+++ b/test/cem-parser.test.ts
@@ -422,7 +422,10 @@ describe("getCssProperties", () => {
       const { args } = getCssProperties(
         makeComponent({
           cssProperties: [
-            { name: "--profile-icon-colour", type: { text: "<string>" } } as never,
+            {
+              name: "--profile-icon-colour",
+              type: { text: "<string>" },
+            } as never,
           ],
         }),
       );
@@ -465,9 +468,7 @@ describe("getCssProperties", () => {
     it("ignores the 'color' name heuristic when useCssPropTypes is true", () => {
       const { args } = getCssProperties(
         makeComponent({
-          cssProperties: [
-            { name: "--primary-color" },
-          ],
+          cssProperties: [{ name: "--primary-color" }],
         }),
       );
       expect(args["--primary-color"].control).toBe("text");


### PR DESCRIPTION
Closes #59

When `setStorybookHelpersConfig({ useCssPropTypes: true })` is set, `getCssPropControl` relies only on the CSS type (`<color>`, `<number>`, `<integer>`) declared in the `@cssproperty` JSDoc tag to determine the Storybook control. The name-based heuristic (`name.includes("color")` / `name.includes("colour")`) is skipped, avoiding false positives for properties like `--colour-distance` or `--profile-icon-colour`.

**Non-breaking:** defaults to `false` — existing behavior completely unchanged.