### PR TITLE
fix: args using property name (camelCase) now work when attribute name differs

### DIFF
--- a/.changeset/quick-paws-study.md
+++ b/.changeset/quick-paws-study.md
@@ -1,0 +1,7 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix: args using property name (camelCase) now work when the component's attribute name differs from the property name (e.g., `docsHint` property with `docs-hint` attribute)
+
+Previously, the argType was only registered under the attribute name, so `args: { docsHint: "value" }` in a story would have no effect. Now the argType is also registered under the property name, allowing property-name-based args to set the corresponding property on the element.

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -62,7 +62,6 @@ export function getAttributesAndProperties(
     }
 
     const name = attribute?.name || member.name;
-    const argRef = attribute?.name !== member.name ? member.name : undefined;
     const type = helpersOptions.typeRef
       ? (member as any)[`${helpersOptions.typeRef}`]?.text || member?.type?.text
       : member?.type?.text;
@@ -80,7 +79,7 @@ export function getAttributesAndProperties(
       name: name,
       description: getDescription(
         (member as any).summary || member.description,
-        argRef,
+        propName,
         member.deprecated as string,
       ),
       defaultValue,
@@ -97,6 +96,30 @@ export function getAttributesAndProperties(
       },
       type: sbType,
     };
+
+    if (attribute?.name && attribute.name !== member.name) {
+      propArgs[member.name] = {
+        name: member.name,
+        description: getDescription(
+          (member as any).summary || member.description,
+          member.name,
+          member.deprecated as string,
+        ),
+        defaultValue,
+        control: enabled && !member.readonly && control ? control : false,
+        options,
+        table: {
+          category: "properties",
+          defaultValue: {
+            summary: JSON.stringify(defaultValue),
+          },
+          type: {
+            summary: type,
+          },
+        },
+        type: sbType,
+      };
+    }
   });
 
   return { resets, propArgs, attrArgs };


### PR DESCRIPTION
Fixes #52

When a component property has a different attribute name (e.g. `docsHint` property with `docs-hint` attribute), the argType was only registered under the attribute name (`attrArgs[docs-hint]`). This meant args set with the property name like `args: { docsHint: 'value' }` in a story had no effect — the value was never applied to the element.

Now in `getAttributesAndProperties()`, when a field's attribute name differs from its property name, the argType is also registered under the property name in `propArgs`. This allows the `propArgs` handler in `getTemplateOperators()` to match it and set `.docsHint` as a property on the element, which Lit correctly reflects to the `docs-hint` attribute.