### PR TITLE
Fix Storybook RangeControl crash (#47)

### DIFF
--- a/.changeset/dull-dogs-glow.md
+++ b/.changeset/dull-dogs-glow.md
@@ -1,0 +1,9 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix Storybook RangeControl crash when overriding number props with range control
+
+- `cem-parser.ts`: coerce number defaults from string to actual Number type
+- `storybook-helpers.ts`: fix `|| ""` fallback that swallowed falsy values like `0`
+- `html-templates.ts`: parse attribute values as numbers in `syncControls` observer

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -416,6 +416,10 @@ function getDefaultValue(control: StorybookControl, defaultValue?: string) {
   if (initialValue === "''" || initialValue === '""') {
     return "";
   }
+  if (controlType === "number") {
+    return initialValue === "" ? initialValue : Number(initialValue);
+  }
+
   if (controlType === "object" || controlType === "multi-select") {
     return initialValue
       ? JSON.parse(formatToValidJson(initialValue))

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -474,6 +474,17 @@ function setArgObserver(component: Component) {
             mutation.target as HTMLElement
           )?.hasAttribute(mutation.attributeName || ""),
         });
+      } else if (
+        attribute?.control === "number" ||
+        (attribute?.control as any)?.type === "number"
+      ) {
+        updateArgs({
+          [`${mutation.attributeName}`]: Number(
+            (mutation.target as HTMLElement).getAttribute(
+              mutation.attributeName || "",
+            ),
+          ),
+        });
       } else {
         updateArgs({
           [`${mutation.attributeName}`]: (

--- a/src/storybook-helpers.ts
+++ b/src/storybook-helpers.ts
@@ -177,7 +177,10 @@ function getArgs<T>(argTypes: ArgTypes): Partial<T> & { [key: string]: any } {
   const args: Partial<T> & { [key: string]: any } = {};
   for (const [key, value] of Object.entries(argTypes)) {
     if (value?.control) {
-      args[key as keyof T] = getDefaultValue(value.defaultValue) || "";
+      const defaultValue = getDefaultValue(value.defaultValue);
+      if (defaultValue != null) {
+        args[key as keyof T] = defaultValue;
+      }
     }
   }
   return args;


### PR DESCRIPTION
Fixes #47

## Problem

When overloading `argTypes` to use Storybook's `range` control on a number prop, the controls panel crashes with `TypeError: t.toFixed is not a function`. This happens because:

1. `getDefaultValue` in cem-parser returns strings (`"10"`) for number controls instead of actual numbers
2. `getArgs` uses `|| ""` which swallows valid falsy values like `0`
3. The `syncControls` mutation observer reads attribute values via `getAttribute()` (always a string) and feeds them back into args, corrupting numeric values

## Fix

- **cem-parser.ts**: coerce number defaults to actual `Number` type
- **storybook-helpers.ts**: replace `|| ""` with null-check so `0` passes through
- **html-templates.ts**: parse attribute values as `Number` for number controls in the observer