### PR TITLE
fix: make sure slot with no values does not render "undefined" text

### DIFF
--- a/.changeset/clean-moments-obey.md
+++ b/.changeset/clean-moments-obey.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix slots with no content rendering 'undefined' as text node

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -390,7 +390,9 @@ function getSlotsTemplate(
 
       let slotContent = "";
       const container = document.createElement("div");
-      container.innerHTML = slotValue;
+      if (slotValue !== undefined) {
+        container.innerHTML = slotValue;
+      }
 
       for (const child of container.childNodes) {
         if (child instanceof Text) {


### PR DESCRIPTION
Slots with no values set in controls would render `undefined` as a text node.
This small PR fixes that.

<img width="460" height="156" alt="image" src="https://github.com/user-attachments/assets/5636ab7a-7774-437e-8b5e-377184afdf57" />

