### PR TITLE
feat: support handling non-primitive types with custom types

### DIFF
--- a/.changeset/mighty-paths-occur.md
+++ b/.changeset/mighty-paths-occur.md
@@ -1,0 +1,7 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Support handling non-primitive types with custom types
+
+- `cem-parser.ts`: disable controls of non-primitive members, with custom types

--- a/demo/src/my-element4/index.d.ts
+++ b/demo/src/my-element4/index.d.ts
@@ -1,0 +1,1 @@
+declare type RendererFunc = (v: string) => string

--- a/demo/src/my-element4/my-element4.ts
+++ b/demo/src/my-element4/my-element4.ts
@@ -32,6 +32,16 @@ export class MyElement4 extends LitElement {
   @property({type: Object, attribute: 'object-with-attribute'}) objectWithAttributeDefault = {test: 'test-value'};
 
   /**
+   * @type {Document}
+   */
+  @property({attribute: false}) objectCustomType = undefined;
+
+  /**
+   * @type {Document}
+   */
+  @property({attribute: false}) objectCustomTypeDefault = new Document();
+
+  /**
    * @type {Function}
    */
   @property({attribute: false}) functionNoAttribute = undefined;
@@ -40,6 +50,18 @@ export class MyElement4 extends LitElement {
    * @type {Function}
    */
   @property({attribute: false}) functionNoAttributeDefault = i => i + 2;
+
+  @property({attribute: false}) functionCustomType: RendererFunc;
+
+  /**
+   * @type {RendererFunc}
+   */
+  @property({attribute: false}) functionCustomTypeDefault = v => `prefix: ${v}`;
+
+  /**
+   * @type {"one" | "two" | "three"}
+   */
+  @property({type: String}) enumAttribute = undefined;
 
   render() {
     return html`
@@ -58,6 +80,10 @@ export class MyElement4 extends LitElement {
           ${this.__log('objectWithAttributeDefault')}
           ${this.__log('functionNoAttribute')}
           ${this.__log('functionNoAttributeDefault')}
+          ${this.__log('functionCustomType')}
+          ${this.__log('functionCustomTypeDefault')}
+          ${this.__log('objectCustomType')}
+          ${this.__log('objectCustomTypeDefault')}
           </tbody>
       </table>      
     `;

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -71,7 +71,7 @@ export function getAttributesAndProperties(
       options,
       type: sbType,
     } = getControl(propType, attribute !== undefined);
-    const defaultValue = member.readonly
+    const defaultValue = member.readonly || sbType?.name === "other"
       ? undefined
       : getDefaultValue(control, member.default);
 
@@ -88,7 +88,7 @@ export function getAttributesAndProperties(
       table: {
         category: attribute ? "attributes" : "properties",
         defaultValue: {
-          summary: JSON.stringify(defaultValue),
+          summary: defaultValue && JSON.stringify(defaultValue),
         },
         type: {
           summary: type,
@@ -403,15 +403,22 @@ export function getMethods(component?: Component): ArgSet {
 }
 
 function getDefaultValue(control: StorybookControl, defaultValue?: string) {
-  const initialValue = removeQuotes(defaultValue || "");
   const controlType =
     typeof control === "string"
       ? control
       : typeof control === "object"
         ? control.type
         : undefined;
+  if (!controlType && defaultValue === undefined) {
+    // Worst case: we have no information
+    return undefined;
+  }
+  const initialValue = removeQuotes(defaultValue || "");
   if (controlType === "boolean") {
     return initialValue === "true";
+  }
+  if (initialValue === "undefined") {
+    return undefined;
   }
   if (initialValue === "''" || initialValue === '""') {
     return "";
@@ -478,6 +485,12 @@ function getControl(
 
   if (hasType(options, "function")) {
     // Storybook has no dedicated function type; disable control
+    return { control: false, type: {name: "other"} };
+  }
+
+  if (!arrayInner && !isEnum(type)) {
+    // Type is not an array like, not an enum and none of the above. It is assumed
+    // to be a custom type, therefore control is disabled because we cannot infer anything
     return { control: false };
   }
 
@@ -494,6 +507,14 @@ function getControl(
         options: enumValues,
         type: { name: "enum", value: enumValues },
       };
+}
+// matches -> 'one' | 'two' | 'three'
+const singleQuoteEnumRegex = /^\s*'(?:\\'|[^'])*'\s*(?:\|\s*'(?:\\'|[^'])*'\s*)*$/i;
+// matches -> "one" | "two" | "three"
+const doubleQuoteEnumRegex = /^\s*"(?:\\"|[^"])*"\s*(?:\|\s*"(?:\\"|[^"])*"\s*)*$/i;
+
+function isEnum(type: string): boolean {
+  return singleQuoteEnumRegex.test(type) || doubleQuoteEnumRegex.test(type);
 }
 
 function arrayOf(scalar: "string" | "number" | "boolean") {

--- a/test/cem-parser.test.ts
+++ b/test/cem-parser.test.ts
@@ -143,6 +143,21 @@ describe("getAttributesAndProperties — object controls", () => {
     );
     expect(propArgs[FIELD].control).toBe(false);
   });
+
+  it("returns an falsy control for custom type properties", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("MyCustomType", { default: undefined }),
+    );
+    expect(propArgs[FIELD].control).toBe(false);
+  });
+
+  it("returns an falsy control for custom types union properties", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("MyFirstType|MySecondType", { default: undefined }),
+    );
+    expect(propArgs[FIELD].control).toBe(false);
+    console.log(propArgs[FIELD]);
+  });
 });
 
 describe("getAttributesAndProperties — default values", () => {
@@ -242,6 +257,28 @@ describe("getAttributesAndProperties — default values", () => {
     expect(() =>
       getAttributesAndProperties(propComponent("Function")),
     ).not.toThrow();
+  });
+
+  it("returns undefined default value for an object member with custom type", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("MyCustomType", { default: undefined }),
+    );
+    expect(propArgs[FIELD].control).toBe(false);
+  });
+
+  it("doesn't parse object defaults for custom object controls", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("MyCustomType", { default: `{ foo: 'bar' }` }),
+    );
+    expect(propArgs[FIELD].defaultValue).toEqual(`{ foo: 'bar' }`);
+  });
+
+  it("returns undefined default value for an object member with custom type union", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("MyFirstType|MySecondType", { default: undefined }),
+    );
+    expect(propArgs[FIELD].control).toBe(false);
+    console.log(propArgs[FIELD]);
   });
 });
 


### PR DESCRIPTION
Add support for custom types in non-primitive members.
As it is hard to provide convenient controls, since we do not know what the custom type represents, it simply disable storybook controls for those members.

Users can still customize the controls using standard Storybook controls customization.
