### PR TITLE
fix: handle union types combining string literals and object types

### DIFF
--- a/.changeset/quiet-pillows-smile.md
+++ b/.changeset/quiet-pillows-smile.md
@@ -1,0 +1,7 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix crash for union types containing both string literals and an object type
+
+When a property is typed as a union like `'blub' | 'bla' | { test: 'string' }` with a string literal default, the control resolved to "object" and `getDefaultValue` called `JSON.parse` on the raw literal, throwing `SyntaxError`. The control now resolves to a "select" with the string literal options, and `getDefaultValue` guards the `JSON.parse` so an unparseable default falls back to the raw string instead of throwing.

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -430,10 +430,18 @@ function getDefaultValue(control: StorybookControl, defaultValue?: string) {
 
   if (controlType === "object" || controlType === "multi-select") {
     return initialValue && initialValue !== "undefined"
-      ? JSON.parse(formatToValidJson(initialValue))
+      ? safelyParseJson(initialValue)
       : undefined;
   }
   return initialValue;
+}
+
+function safelyParseJson(input: string) {
+  try {
+    return JSON.parse(formatToValidJson(input));
+  } catch {
+    return input;
+  }
 }
 
 function getControl(
@@ -454,7 +462,18 @@ function getControl(
 
   const options = arrayInner ? parseOptions(arrayInner) : parseOptions(type);
 
-  if (!arrayInner && isObject(type) && !isAttribute) {
+  // A union may mix string literals with object/record members (e.g.
+  // `'blub' | 'bla' | { test: 'string' }`). Surface the string literals as
+  // select/multi-select options instead of falling back to an object control,
+  // which would otherwise try to JSON.parse a literal default value (see #103).
+  const literalOptions = options.filter(isStringLiteral);
+
+  if (
+    !arrayInner &&
+    isObject(type) &&
+    !isAttribute &&
+    literalOptions.length === 0
+  ) {
     return { control: "object", type: getObjectSBType(type) };
   }
 
@@ -489,14 +508,16 @@ function getControl(
     return { control: false, type: { name: "other" } };
   }
 
-  if (!arrayInner && !isEnum(type)) {
+  const hasMixedObjectUnion = literalOptions.length > 0 && isObject(type);
+
+  if (!arrayInner && !isEnum(type) && !hasMixedObjectUnion) {
     // Type is not an array like, not an enum and none of the above. It is assumed
     // to be a custom type, therefore control is disabled because we cannot infer anything
     return { control: false };
   }
 
-  // base case, type is a union of literals
-  const enumValues = options.map((option) => removeQuotes(option));
+  // base case, type is a union of literals (optionally mixed with object members)
+  const enumValues = literalOptions.map((option) => removeQuotes(option));
   return arrayInner
     ? {
         control: "multi-select",
@@ -518,6 +539,10 @@ const doubleQuoteEnumRegex =
 
 function isEnum(type: string): boolean {
   return singleQuoteEnumRegex.test(type) || doubleQuoteEnumRegex.test(type);
+}
+
+function isStringLiteral(option: string): boolean {
+  return option.startsWith("'") || option.startsWith('"');
 }
 
 function arrayOf(scalar: "string" | "number" | "boolean") {

--- a/test/cem-parser.test.ts
+++ b/test/cem-parser.test.ts
@@ -60,6 +60,26 @@ describe("getAttributesAndProperties — union of literals (select)", () => {
     );
     expect(attrArgs[FIELD].options).toEqual(["TopLeft", "BottomRight"]);
   });
+
+  it("resolves a union of string literals mixed with an object type to a select (#103)", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("'blub' | 'bla' | { test: 'string' }", {
+        default: "'bla'",
+      }),
+    );
+    expect(propArgs[FIELD].control).toBe("select");
+    expect(propArgs[FIELD].options).toEqual(["blub", "bla"]);
+  });
+
+  it("does not throw when an object-type union has a string literal default (#103)", () => {
+    expect(() =>
+      getAttributesAndProperties(
+        propComponent("'blub' | 'bla' | { test: 'string' }", {
+          default: "'bla'",
+        }),
+      ),
+    ).not.toThrow();
+  });
 });
 
 describe("getAttributesAndProperties — array of literal unions (multi-select)", () => {
@@ -251,6 +271,13 @@ describe("getAttributesAndProperties — default values", () => {
     expect(() =>
       getAttributesAndProperties(propComponent("Object")),
     ).not.toThrow();
+  });
+
+  it("returns the raw default when an object control default is not valid JSON (#103)", () => {
+    const { propArgs } = getAttributesAndProperties(
+      propComponent("Object", { default: "'bla'" }),
+    );
+    expect(propArgs[FIELD].defaultValue).toBe("bla");
   });
 
   it("does not throw on a function field", () => {


### PR DESCRIPTION
## Summary

Since v10.6.0, a property typed as a union containing both string literals and an object type (e.g. `'blub' | 'bla' | { test: 'string' }`) with a string literal default crashes with `SyntaxError: ... is not valid JSON`.

**Root cause:** `getControl` classifies any type containing `{`, `[`, `<`, "array" or "object" as an `object` control. For the union above it returns `object`, then `getDefaultValue` runs `JSON.parse(formatToValidJson('bla'))` unguarded and throws.

## Changes (`src/cem-parser.ts`)

1. **Select control for mixed unions** — `getControl` now collects quoted string literal members (`literalOptions`). When a union mixes literals with object members, the string literals are surfaced as a `select`/`multi-select` with only those literal options (so `'blub' | 'bla' | { test: 'string' }` becomes a `select` of `['blub', 'bla']`), instead of falling back to the object control.
2. **Guarded `JSON.parse`** — `getDefaultValue` now uses `safelyParseJson`, which returns the raw string when the default isn't valid JSON rather than throwing (defense-in-depth for any remaining object-control case).

## Tests

- Union of literals + object resolves to a `select` with the literal options
- No throw when such a union has a string literal default
- Object control with a non-JSON default returns the raw default instead of throwing

All 91 tests pass, eslint clean, `tsup` build succeeds. Regression tests reference #103.

Fixes #103