### PR TITLE
fix: restore empty string default for args with no default value

### DIFF
--- a/.changeset/cyan-otters-attend.md
+++ b/.changeset/cyan-otters-attend.md
@@ -1,0 +1,9 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Fix regression where args without a default value were omitted entirely
+
+v10.7.2 stopped adding args whose default value resolved to `undefined` or `null` (a change made to fix the RangeControl crash for falsy `0` values). This meant args for named slots, CSS parts, CSS states, and properties/references without a declared default were left unset, which broke components that rendered those arg values directly and threw errors in Storybook.
+
+Args with no resolvable default are now initialized to `''` again, while falsy defaults (`0`, `false`, `""`) are still preserved, so the RangeControl fix keeps working.

--- a/src/storybook-helpers.test.ts
+++ b/src/storybook-helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { makeComponent } from "../test/helpers/make-component.js";
+import type { Package } from "custom-elements-manifest";
+
+const component = makeComponent({
+  fields: [
+    { name: "label", type: { text: "string" } },
+    { name: "count", type: { text: "number" }, default: "0" },
+    { name: "data", type: { text: "{ foo: 'bar' }" } },
+  ],
+  attributes: [{ name: "label", fieldName: "label" }],
+  slots: [{ name: "default", description: "default slot" }],
+  cssParts: [{ name: "foo" }],
+  cssStates: [{ name: "open" }],
+});
+
+const manifest = {
+  schemaVersion: "1.0.0",
+  modules: [
+    {
+      kind: "javascript-module",
+      path: "test.js",
+      declarations: [
+        {
+          kind: "class",
+          customElement: true,
+          ...(component as Record<string, unknown>),
+        },
+      ],
+      exports: [],
+    },
+  ],
+} as unknown as Package;
+
+describe("getStorybookHelpers > getArgs", () => {
+  let args: Record<string, unknown>;
+
+  beforeAll(async () => {
+    (globalThis as Record<string, unknown>).window = globalThis;
+    (
+      globalThis as Record<string, unknown>
+    ).__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__ = manifest;
+    const mod = await import("./storybook-helpers.js");
+    args = mod.getStorybookHelpers("test-element").args;
+  });
+
+  it("initializes args without a default value to an empty string", () => {
+    expect(args["label"]).toBe("");
+    expect(args["default-slot"]).toBe("");
+    expect(args["foo-part"]).toBe("");
+    expect(args["open-state"]).toBe("");
+    expect(args["data"]).toBe("");
+  });
+
+  it("preserves falsy default values", () => {
+    expect(args["count"]).toBe(0);
+  });
+});

--- a/src/storybook-helpers.ts
+++ b/src/storybook-helpers.ts
@@ -178,9 +178,7 @@ function getArgs<T>(argTypes: ArgTypes): Partial<T> & { [key: string]: any } {
   for (const [key, value] of Object.entries(argTypes)) {
     if (value?.control) {
       const defaultValue = getDefaultValue(value.defaultValue);
-      if (defaultValue != null) {
-        args[key as keyof T] = defaultValue;
-      }
+      args[key as keyof T] = defaultValue == null ? "" : defaultValue;
     }
   }
   return args;


### PR DESCRIPTION
## Description

Fixes the rest of #101. The v10.7.2 regression ([commit 0b3f1d9](https://github.com/wc-toolkit/storybook-helpers/commit/0b3f1d93b6712c4221d7efafafb92dfc498e0fb3), added for #47) stopped adding args whose default value resolves to `undefined`/`null`, since it only set the arg when the default was non-null. PR #104 guarded the crash on the render side for `@csspart`/CSS state controls only; it did not fix the source, so named slots, CSS parts, CSS states, and properties without a declared default were still omitted from the `args` object and broke those stories.

## Changes

- `src/storybook-helpers.ts` — `getArgs` now initializes args with no resolvable default to `''`, while preserving falsy defaults (`0`, `false`, ``), keeping the #47 RangeControl fix intact.
- `src/storybook-helpers.test.ts` — regression tests covering a slot, CSS part, CSS state, and object property with no default, plus a falsy `0` default.
- Added a patch changeset.

## Verification

Confirmed the new tests fail without the fix (red) and pass with it (green). All 90 tests pass; lint and format checks are clean.

Closes #101