### PR TITLE
fix: scope empty-string default to workaround controls only

### DIFF
--- a/.changeset/thin-melons-search.md
+++ b/.changeset/thin-melons-search.md
@@ -1,0 +1,9 @@
+---
+"@wc-toolkit/storybook-helpers": patch
+---
+
+Scope the empty-string default fallback to workaround controls only
+
+v10.7.6 initialized args to `''` for every control with no resolvable default. That restored CSS part/state/slot controls, but it also synthesized `''` for real component attributes and properties, which made the generated template render `.prop="${''}"` and override the component's own default values.
+
+Now the `''` fallback only applies to the workaround categories (`css shadow parts`, `css states`, `slots`). Attributes and properties with no declared default are left unset, so components keep their own defaults. Arrow-function/custom-typed properties (e.g. `() => string`) were already excluded since they resolve to a disabled control.

--- a/src/cem-parser.ts
+++ b/src/cem-parser.ts
@@ -17,6 +17,21 @@ type ArgSet = {
 
 type StorybookControl = ArgTypes[string]["control"];
 
+/**
+ * Categories whose controls are synthetic "workarounds" rather than real
+ * component state: the arg's string value is freeform content (CSS or slot
+ * markup) that the template substitutes into a CSS rule or `<slot>`.
+ *
+ * These are the only categories that should fall back to an empty string when
+ * no default is set, so Storybook still renders an (empty) control without
+ * clobbering a component's own defaults.
+ */
+export const contentArgCategories = [
+  "css shadow parts",
+  "css states",
+  "slots",
+] as const;
+
 let helpersOptions: StorybookHelpersOptions = {};
 
 setTimeout(() => {

--- a/src/storybook-helpers.test.ts
+++ b/src/storybook-helpers.test.ts
@@ -7,6 +7,9 @@ const component = makeComponent({
     { name: "label", type: { text: "string" } },
     { name: "count", type: { text: "number" }, default: "0" },
     { name: "data", type: { text: "{ foo: 'bar' }" } },
+    { name: "renderer", type: { text: "() => string" } },
+    { name: "dataSet", type: { text: "Set<string>" } },
+    { name: "dataMap", type: { text: "Map<string, number>" } },
   ],
   attributes: [{ name: "label", fieldName: "label" }],
   slots: [{ name: "default", description: "default slot" }],
@@ -44,12 +47,17 @@ describe("getStorybookHelpers > getArgs", () => {
     args = mod.getStorybookHelpers("test-element").args;
   });
 
-  it("initializes args without a default value to an empty string", () => {
-    expect(args["label"]).toBe("");
+  it("initializes workaround controls without a default value to empty strings", () => {
     expect(args["default-slot"]).toBe("");
     expect(args["foo-part"]).toBe("");
     expect(args["open-state"]).toBe("");
-    expect(args["data"]).toBe("");
+  });
+
+  it("does not set args for attributes/properties without a default value", () => {
+    expect(args["data"]).toBeUndefined();
+    expect(args["renderer"]).toBeUndefined();
+    expect(args["dataSet"]).toBeUndefined();
+    expect(args["dataMap"]).toBeUndefined();
   });
 
   it("preserves falsy default values", () => {

--- a/src/storybook-helpers.ts
+++ b/src/storybook-helpers.ts
@@ -11,6 +11,7 @@ import {
   getEvents,
   getCssStates,
   getMethods,
+  contentArgCategories,
 } from "./cem-parser.js";
 import { Component, getComponentByTagName } from "@wc-toolkit/cem-utilities";
 import type { ArgTypes } from "@storybook/web-components";
@@ -178,7 +179,13 @@ function getArgs<T>(argTypes: ArgTypes): Partial<T> & { [key: string]: any } {
   for (const [key, value] of Object.entries(argTypes)) {
     if (value?.control) {
       const defaultValue = getDefaultValue(value.defaultValue);
-      args[key as keyof T] = defaultValue == null ? "" : defaultValue;
+      if (defaultValue != null) {
+        args[key as keyof T] = defaultValue;
+      } else if (
+        contentArgCategories.some((c) => c === value?.table?.category)
+      ) {
+        (args as { [key: string]: any })[key] = "";
+      }
     }
   }
   return args;


### PR DESCRIPTION
## Description

Closes #110. v10.7.6 (#107, the fix for #101) initialized args to `''` for **every** control with no resolvable default. That restored the CSS part/state/slot controls, but it also synthesized `''` for real component attributes/properties, making the generated template render `.prop="${''}"` and override the component's own defaults (e.g. function/object-typed properties).

## Changes

- `src/storybook-helpers.ts` — `getArgs` now applies the `''` fallback only to the workaround categories. Attributes/properties with no declared default are left unset so components keep their own defaults.
- `src/cem-parser.ts` — added a single source of truth, the exported `contentArgCategories` const (`["css shadow parts", "css states", "slots"]`), co-located with where the `table.category` labels are authored, so the fallback list can't silently drift from the categories.
- `src/storybook-helpers.test.ts` — regression tests asserting object-typed, arrow-function (`() => string`), `Set<string>`, and `Map<string, number>` properties are left unset, while slot/CSS part/CSS state controls still default to `''`.

## Notes

- `() => string`, `Set`, `Map`, and custom types resolve to `control: false` or land in the `properties` category, so they're covered either way.
- The `events`/`methods` categories already use `control: false` and the cssProps category is guarded by truthiness in `getCssPropTemplate`, so neither needs the fallback.
- Implements the approach discussed by the reporter in #110.

## Verification

All 94 tests pass; lint and format checks are clean.