### PR TITLE
feat: Add support for providing event handlers using function syntax

### DIFF
--- a/src/html-templates.test.ts
+++ b/src/html-templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
-import { transformToScoped } from "./html-templates.js";
+import { getTemplateOperators, transformToScoped } from "./html-templates.js";
 import { makeComponent } from "../test/helpers/make-component.js";
 
 describe("transformToScoped", () => {
@@ -88,5 +88,15 @@ describe("getStyleTemplate > CSS states", () => {
     );
     expect(html).toContain("test-element:state(open)");
     expect(html).toContain("display: block");
+  });
+});
+
+describe("getTemplateOperators", () => {
+  it("accepts functions as args with event prefix", () => {
+    const component = makeComponent({ events: [] });
+    const { additionalAttrs } = getTemplateOperators(component, {
+      "@click": function () {},
+    });
+    expect(typeof additionalAttrs["@click"]).toBe("function");
   });
 });

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -247,7 +247,10 @@ function getTemplateOperators(
     .filter((x) => !Object.keys(argTypes || {}).includes(x))
     .forEach((key) => {
       // exclude Storybook event listeners
-      if (!key.startsWith("on") && typeof args[key] !== "function") {
+      if (
+        key.startsWith("@") ||
+        (!key.startsWith("on") && typeof args[key] !== "function")
+      ) {
         additionalAttrs[key] = args[key];
       }
     });

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -204,7 +204,7 @@ function excludeCategory(
  * @param args args object from Storybook story
  * @returns object of properties and attributes with their values
  */
-function getTemplateOperators(
+export function getTemplateOperators(
   component: Component,
   args: any,
   argTypes?: ArgTypes,


### PR DESCRIPTION
Closes #63 

This adds support for event handlers as functions as direct arguments to the template function:

```js
export const LinkExample = {
  render: (args) => template({
    '@click': (e) => {
      // Do not navigate away from story
      e.preventDefault();
      // but log an action
      logEvent("click", e);
    },
    ...args
  }),
  args: {
    href: "https://example.com"
  }
}

```